### PR TITLE
use --arg / --argjson in jq script to handle spaces

### DIFF
--- a/latest_artifact.sh
+++ b/latest_artifact.sh
@@ -15,7 +15,9 @@ echoerr() { echo "$@" 1>&2; }
 workflows_url="https://api.github.com/repos/${repository}/actions/workflows"
 workflows=$(curl -sS -H "Authorization: Bearer ${github_token}" "${workflows_url}")
 latest_workflow_id=$(echo ${workflows} \
-	| jq '.workflows[] | select(.name=="'${workflow_name}'").id' || echo "ERROR")
+	| jq \
+		--arg workflow_name "$workflow_name" \
+		'.workflows[] | select(.name==$workflow_name).id' || echo "ERROR")
 
 if [ "${latest_workflow_id}" = "ERROR" ]; then
 	echoerr 'Failed to parse GitHub response with jq:'
@@ -32,8 +34,11 @@ echoerr "Latest workflow ID: ${latest_workflow_id}"
 
 workflow_runs_url="https://api.github.com/repos/${repository}/actions/workflows/${latest_workflow_id}/runs?status=success&branch=${branch_name}"
 workflow_runs=$(curl -sS -H "Authorization: Bearer ${github_token}" "${workflow_runs_url}")
-latest_workflow_run_id=$(echo ${workflow_runs} \
-		| jq '([.workflow_runs[] | select(.pull_requests | any(.number == '${pr_number}'))] | max_by(.run_number)) | .id' || echo "ERROR")
+latest_workflow_run_id=$(\
+	echo ${workflow_runs} \
+	| jq \
+		--argjson pr_number "${pr_number}" \
+		'([.workflow_runs[] | select(.pull_requests | any(.number == $pr_number))] | max_by(.run_number)) | .id' || echo "ERROR")
 
 
 if [ "${latest_workflow_run_id}" = "ERROR" ]; then
@@ -52,7 +57,9 @@ echoerr "Latest workflow run ID: ${latest_workflow_run_id}"
 artifacts_url="https://api.github.com/repos/${repository}/actions/runs/${latest_workflow_run_id}/artifacts"
 artifacts=$(curl -sS -H "Authorization: Bearer ${github_token}" "${artifacts_url}")
 latest_artifact_id=$(echo ${artifacts} \
-	| jq '.artifacts[] | select(.name=="'${artifact_name}'").id' || echo "ERROR")
+	| jq \
+		--arg artifact_name "$artifact_name" \
+		'.artifacts[] | select(.name==$artifact_name).id' || echo "ERROR")
 
 if [ "${latest_artifact_id}" = "ERROR" ]; then
 	echoerr 'Failed to parse GitHub response with jq:'


### PR DESCRIPTION
## What

Use `--arg` and `--argjson` in `latest_artifact.sh`

## Why

- This is the idiomatic way to handle arguments in `jq`.
- The current bash string interpolation approach doesn't support whitespace in arguments
