### PR TITLE
Safer WorkflowRunsResponse parsing

### DIFF
--- a/latest_artifact.sh
+++ b/latest_artifact.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Adapted from: https://gist.github.com/Willsr71/e4884be88f98b4c298692975c0ec8edb
 
 
@@ -32,8 +32,7 @@ echoerr "Latest workflow ID: ${latest_workflow_id}"
 
 workflow_runs_url="https://api.github.com/repos/${repository}/actions/workflows/${latest_workflow_id}/runs?status=success&branch=${branch_name}"
 workflow_runs=$(curl -sS -H "Authorization: Bearer ${github_token}" "${workflow_runs_url}")
-latest_workflow_run_id=$(echo ${workflow_runs} \
-		| jq '([.workflow_runs[] | select(.pull_requests | any(.number == '${pr_number}'))] | max_by(.run_number)) | .id' || echo "ERROR")
+latest_workflow_run_id=$(jq '([.workflow_runs[] | select(.pull_requests | any(.number == '${pr_number}'))] | max_by(.run_number)) | .id' <<< ${workflow_runs} || echo "ERROR")
 
 
 if [ "${latest_workflow_run_id}" = "ERROR" ]; then


### PR DESCRIPTION
Give JQ the WorkflowRunsResponse JSON document through stdinput directly to avoid escaping problems for line breaks and such.

When the API returns pretty-printed JSON:
```
{
    "workflow_runs": [{
        "id": 123456,
        "name": "dismiss-stale-approvals",
        "pull_requests": [],
        "head_commit": {
            "message": "Subject
            
Content"
        }
    }]
}
```
The line breaks are problematic. 

