### PR TITLE
Use PR number given in the event context

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
     - name: Download SHAs from last run
       shell: bash
       run: |
-        latest_artifact.sh "${{ inputs.github-token }}" "${{ github.repository }}" "$(echo ${{github.ref_name}} | cut -d '/' -f 1)" "${{ github.head_ref }}" "${{ github.workflow }}" "dismiss-stale-approvals-shas" || true
+        latest_artifact.sh "${{ inputs.github-token }}" "${{ github.repository }}" "${{ github.event.pull_request.number }}" "${{ github.head_ref }}" "${{ github.workflow }}" "dismiss-stale-approvals-shas" || true
         if [ -f shas.txt ]; then
           echo "PREV_HEAD_SHA=$(head -n 1 shas.txt)" >> $GITHUB_ENV
           echo "PREV_BASE_SHA=$(tail -n 1 shas.txt)" >> $GITHUB_ENV


### PR DESCRIPTION
This change drops the branch name parsing in favor of the PR number in the Github pull_request event.

Existing workflows using `on: pull_request` this will continue to work as they are, since the branch name and PR number match.

For workflows using `on: pull_request_target` this will allow the action to operate in the same way at it does on `pull_request` events.