### PR TITLE
Default to dismiss and upload only after succesful check

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,28 +49,14 @@ runs:
        echo "HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
        echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
 
-    - name: Write SHAs to file
-      shell: bash
-      run: |
-        echo "${{ env.HEAD_SHA }}" > shas.txt
-        echo "${{ env.BASE_SHA }}" >> shas.txt
-
-    - name: Upload SHAs
-      uses: actions/upload-artifact@v4
-      continue-on-error: true
-      id: artifact-upload-step
-      with:
-        name: dismiss-stale-approvals-shas
-        path: shas.txt
-
     - name: Check if diff has changed
       continue-on-error: true
       id: check
       shell: bash
       run: |
-        if [ -z ${{ env.PREV_HEAD_SHA }} ] || [ -z ${{ env.PREV_BASE_SHA }} ]; then
+        if [ -z "${{ env.PREV_HEAD_SHA }}" ] || [ -z "${{ env.PREV_BASE_SHA }}" ]; then
           echo ::notice:: "No previous SHAs found; behaving as if diff has changed"
-          echo MATCH="0" >> $GITHUB_ENV
+          echo "MATCH=-1" >> $GITHUB_ENV
           exit 0
         fi
 
@@ -84,34 +70,51 @@ runs:
         echo "Merge bases: $PREV_MERGE_BASE $MERGE_BASE"
 
         RANGE_DIFF=$(git range-diff "$PREV_MERGE_BASE".."${{ env.PREV_HEAD_SHA }}" "$MERGE_BASE".."${{ env.HEAD_SHA }}")
-        MATCH=$(echo "$RANGE_DIFF" | awk '{print $3}' | grep -vq '^=$'; echo $?)
-        echo MATCH="$MATCH" >> $GITHUB_ENV
-        if [ "$MATCH" == "0" ]; then
-          # Run git range-diff again with colors to make it easier to read
+        HAS_CHANGES=$(echo "$RANGE_DIFF" | awk '{print $3}' | grep -vq '^=$'; echo $?)
+
+        if [ "$HAS_CHANGES" == "0" ]; then
+          echo "MATCH=0" >> $GITHUB_ENV
           echo ::notice:: "PR was modified:
         $(git range-diff --color=always "$PREV_MERGE_BASE".."${{ env.PREV_HEAD_SHA }}" "$MERGE_BASE".."${{ env.HEAD_SHA }}")"
         else
+          echo "MATCH=1" >> $GITHUB_ENV
           echo "PR was not modified, range diff for debugging:"
           echo "$RANGE_DIFF"
         fi
 
-    - name: Construct dismissal reason
+    - name: Write SHAs to file
+      if: env.MATCH != ''
       shell: bash
       run: |
-        if [ "${{ env.NO_PREV_SHAS }}" == "1" ]; then
-          DETAILS="Could not find data on the previous version of this PR; see action logs at "
-        elif [ "${{ env.MATCH }}" == "0" ]; then
+        echo "${{ env.HEAD_SHA }}" > shas.txt
+        echo "${{ env.BASE_SHA }}" >> shas.txt
+
+    - name: Upload SHAs
+      if: env.MATCH != ''
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
+      id: artifact-upload-step
+      with:
+        name: dismiss-stale-approvals-shas
+        path: shas.txt
+
+    - name: Construct dismissal reason
+      if: env.MATCH != '1'
+      shell: bash
+      run: |
+        if [ "${{ env.MATCH }}" == "0" ]; then
           DETAILS='See the output of `git range-diff` at '
+        elif [ "${{ env.MATCH }}" == "-1" ]; then
+          DETAILS="No previous SHAs found; treated as if diff has changed at "
         else
           DETAILS="Failed to check if diff has changed; see action logs at "
         fi
         echo "REASON=Your organization requires reapproval when changes are made, so Graphite has dismissed approvals. ${DETAILS}${{ env.WORKFLOW_RUN_URL }}" >> $GITHUB_ENV
 
-    - name: Dismiss approvals if diff has changed or if any prior step failed
-      if: env.MATCH == '0' || env.NO_PREV_SHAS == '1'
+    - name: Dismiss approvals unless diff is proven unchanged
+      if: env.MATCH != '1'
       uses: withgraphite/dismiss-all-approvals-js@main
       with:
         github-token: ${{ inputs.github-token }}
         dry-run: ${{ inputs.dry-run }}
         reason: ${{ env.REASON }}
-


### PR DESCRIPTION
### TL;DR

Improved the logic for determining when to dismiss stale approvals by only saving SHA artifacts after successful diff checks and clarifying the conditions under which approvals are dismissed.|



MATCH = 1: Diff unchanged

MATCH = 0: Diff changed, dismiss

MATCH = -1: We don't have previous upload, upload current and dismiss  
MATCH = unset: some form of failure, dismiss

Fixes

1. Default to dismissal. MATCH is unset and set to 1 or 0 or -1. If anything fails in between, we dismiss
2. Only upload SHAs after a successful check, where MATCH exists. Move the artifact upload to after the check step and gate it on `MATCH`. being set. If the check fails, the artifact from the last successful run remains. The next run downloads that older baseline and compares the full span of unchecked changes, rather than skipping over the failed transition.

### What changed?

- Moved the SHA file writing and artifact upload steps to occur only after a successful diff check
- Added conditional guards to prevent SHA artifacts from being saved when the diff check fails
- Refined the `MATCH` environment variable logic to only set it on conclusive results (0 for changes detected, 1 for no changes)
- Updated the dismissal reason construction to only run when `MATCH != '1'`
- Changed the final dismissal step condition from checking multiple failure states to simply checking if the diff is not proven unchanged

### How to test?

Test with pull requests in different scenarios:

1. A PR with no previous SHA data available
2. A PR where the diff has actually changed between runs
3. A PR where the diff remains unchanged between runs
4. A PR where the diff check step fails

Verify that approvals are only preserved when the diff is conclusively proven to be unchanged.

### Why make this change?

This change makes the approval dismissal logic more robust by ensuring SHA artifacts are only saved when we have reliable data, and simplifies the decision logic to be more conservative - only preserving approvals when we can definitively prove the diff hasn't changed, rather than trying to handle multiple edge cases.