### PR TITLE
update action with MATCH state

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,28 +49,16 @@ runs:
        echo "HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
        echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
 
-    - name: Write SHAs to file
-      shell: bash
-      run: |
-        echo "${{ env.HEAD_SHA }}" > shas.txt
-        echo "${{ env.BASE_SHA }}" >> shas.txt
-
-    - name: Upload SHAs
-      uses: actions/upload-artifact@v4
-      continue-on-error: true
-      id: artifact-upload-step
-      with:
-        name: dismiss-stale-approvals-shas
-        path: shas.txt
-
     - name: Check if diff has changed
       continue-on-error: true
       id: check
       shell: bash
       run: |
-        if [ -z ${{ env.PREV_HEAD_SHA }} ] || [ -z ${{ env.PREV_BASE_SHA }} ]; then
+        echo "MATCH=0" >> $GITHUB_ENV
+
+        if [ -z "${{ env.PREV_HEAD_SHA }}" ] || [ -z "${{ env.PREV_BASE_SHA }}" ]; then
           echo ::notice:: "No previous SHAs found; behaving as if diff has changed"
-          echo MATCH="0" >> $GITHUB_ENV
+          echo "MATCH=-1" >> $GITHUB_ENV
           exit 0
         fi
 
@@ -84,34 +72,51 @@ runs:
         echo "Merge bases: $PREV_MERGE_BASE $MERGE_BASE"
 
         RANGE_DIFF=$(git range-diff "$PREV_MERGE_BASE".."${{ env.PREV_HEAD_SHA }}" "$MERGE_BASE".."${{ env.HEAD_SHA }}")
-        MATCH=$(echo "$RANGE_DIFF" | awk '{print $3}' | grep -vq '^=$'; echo $?)
-        echo MATCH="$MATCH" >> $GITHUB_ENV
-        if [ "$MATCH" == "0" ]; then
-          # Run git range-diff again with colors to make it easier to read
+        HAS_CHANGES=$(echo "$RANGE_DIFF" | awk '{print $3}' | grep -vq '^=$'; echo $?)
+
+        if [ "$HAS_CHANGES" == "0" ]; then
+          echo "MATCH=0" >> $GITHUB_ENV
           echo ::notice:: "PR was modified:
         $(git range-diff --color=always "$PREV_MERGE_BASE".."${{ env.PREV_HEAD_SHA }}" "$MERGE_BASE".."${{ env.HEAD_SHA }}")"
         else
+          echo "MATCH=1" >> $GITHUB_ENV
           echo "PR was not modified, range diff for debugging:"
           echo "$RANGE_DIFF"
         fi
 
-    - name: Construct dismissal reason
+    - name: Write SHAs to file
+      if: steps.check.outcome == 'success'
       shell: bash
       run: |
-        if [ "${{ env.NO_PREV_SHAS }}" == "1" ]; then
-          DETAILS="Could not find data on the previous version of this PR; see action logs at "
-        elif [ "${{ env.MATCH }}" == "0" ]; then
+        echo "${{ env.HEAD_SHA }}" > shas.txt
+        echo "${{ env.BASE_SHA }}" >> shas.txt
+
+    - name: Upload SHAs
+      if: steps.check.outcome == 'success'
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
+      id: artifact-upload-step
+      with:
+        name: dismiss-stale-approvals-shas
+        path: shas.txt
+
+    - name: Construct dismissal reason
+      if: env.MATCH != '1'
+      shell: bash
+      run: |
+        if [ "${{ env.MATCH }}" == "0" ]; then
           DETAILS='See the output of `git range-diff` at '
+        elif [ "${{ env.MATCH }}" == "-1" ]; then
+          DETAILS="No previous SHAs found; treated as if diff has changed at "
         else
           DETAILS="Failed to check if diff has changed; see action logs at "
         fi
         echo "REASON=Your organization requires reapproval when changes are made, so Graphite has dismissed approvals. ${DETAILS}${{ env.WORKFLOW_RUN_URL }}" >> $GITHUB_ENV
 
-    - name: Dismiss approvals if diff has changed or if any prior step failed
-      if: env.MATCH == '0' || env.NO_PREV_SHAS == '1'
+    - name: Dismiss approvals unless diff is proven unchanged
+      if: env.MATCH != '1'
       uses: withgraphite/dismiss-all-approvals-js@main
       with:
         github-token: ${{ inputs.github-token }}
         dry-run: ${{ inputs.dry-run }}
         reason: ${{ env.REASON }}
-


### PR DESCRIPTION
### TL;DR

Improved the logic flow by moving SHA artifact upload after diff checking and adding proper conditionals to prevent unnecessary operations.



MATCH = 1: Diff unchanged

MATCH = 0: Diff changed, dismiss

MATCH = -1: We don't have previous upload, upload current and dismiss  
MATCH = unset: some form of failure, dismiss

### What changed?

- Moved the "Write SHAs to file" and "Upload SHAs" steps to execute after the diff check instead of before
- Added conditional checks (`if: env.MATCH != ''` and `if: env.MATCH != '1'`) to prevent these steps from running when unnecessary
- Fixed shell variable quoting by adding quotes around `${{ env.PREV_HEAD_SHA }}` and `${{ env.PREV_BASE_SHA }}`
- Renamed the `MATCH` variable logic to use `HAS_CHANGES` for clarity and explicitly set `MATCH` environment variable in both branches
- Updated the dismissal reason construction to remove the `NO_PREV_SHAS` condition check
- Changed the final step condition from checking multiple specific conditions to simply `env.MATCH != '1'`

### How to test?

Test with pull requests in different scenarios:

1. A new PR with no previous SHA data
2. A PR that has been modified since last run
3. A PR that hasn't been modified since last run
4. Verify that SHA artifacts are only uploaded when the diff check completes successfully

### Why make this change?

This change optimizes the workflow by avoiding unnecessary file operations and artifact uploads when the diff check fails or when we already know the diff hasn't changed. It also simplifies the conditional logic by consolidating the decision-making into a single `MATCH` variable that clearly indicates whether approvals should be dismissed.