### PR TITLE
Harden action check flow to fail closed and persist last good baseline

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,28 +49,16 @@ runs:
        echo "HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
        echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
 
-    - name: Write SHAs to file
-      shell: bash
-      run: |
-        echo "${{ env.HEAD_SHA }}" > shas.txt
-        echo "${{ env.BASE_SHA }}" >> shas.txt
-
-    - name: Upload SHAs
-      uses: actions/upload-artifact@v4
-      continue-on-error: true
-      id: artifact-upload-step
-      with:
-        name: dismiss-stale-approvals-shas
-        path: shas.txt
-
     - name: Check if diff has changed
       continue-on-error: true
       id: check
       shell: bash
       run: |
-        if [ -z ${{ env.PREV_HEAD_SHA }} ] || [ -z ${{ env.PREV_BASE_SHA }} ]; then
+        # Fail closed: default to dismiss until we fully prove the diff is unchanged.
+        echo MATCH="0" >> $GITHUB_ENV
+
+        if [ -z "${{ env.PREV_HEAD_SHA }}" ] || [ -z "${{ env.PREV_BASE_SHA }}" ]; then
           echo ::notice:: "No previous SHAs found; behaving as if diff has changed"
-          echo MATCH="0" >> $GITHUB_ENV
           exit 0
         fi
 
@@ -84,16 +72,33 @@ runs:
         echo "Merge bases: $PREV_MERGE_BASE $MERGE_BASE"
 
         RANGE_DIFF=$(git range-diff "$PREV_MERGE_BASE".."${{ env.PREV_HEAD_SHA }}" "$MERGE_BASE".."${{ env.HEAD_SHA }}")
-        MATCH=$(echo "$RANGE_DIFF" | awk '{print $3}' | grep -vq '^=$'; echo $?)
-        echo MATCH="$MATCH" >> $GITHUB_ENV
-        if [ "$MATCH" == "0" ]; then
+        HAS_DIFF=$(echo "$RANGE_DIFF" | awk '{if ($3 != "=") {print "1"; exit}}')
+        if [ "$HAS_DIFF" == "1" ]; then
           # Run git range-diff again with colors to make it easier to read
           echo ::notice:: "PR was modified:
         $(git range-diff --color=always "$PREV_MERGE_BASE".."${{ env.PREV_HEAD_SHA }}" "$MERGE_BASE".."${{ env.HEAD_SHA }}")"
         else
           echo "PR was not modified, range diff for debugging:"
           echo "$RANGE_DIFF"
+          # Only mark as safe after the entire comparison succeeds with no differences.
+          echo MATCH="1" >> $GITHUB_ENV
         fi
+
+    - name: Write SHAs to file
+      if: steps.check.outcome == 'success'
+      shell: bash
+      run: |
+        echo "${{ env.HEAD_SHA }}" > shas.txt
+        echo "${{ env.BASE_SHA }}" >> shas.txt
+
+    - name: Upload SHAs
+      if: steps.check.outcome == 'success'
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
+      id: artifact-upload-step
+      with:
+        name: dismiss-stale-approvals-shas
+        path: shas.txt
 
     - name: Construct dismissal reason
       shell: bash


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- default the check to `MATCH=0` at the start of the check step, before any git operations
- only set `MATCH=1` after the range comparison completes successfully and confirms no diff changes
- move SHA artifact persistence to run after the check and gate both write/upload on `steps.check.outcome == 'success'`

## Why
- this enforces fail-closed behavior: any failure during comparison keeps dismissal behavior active
- failed check runs no longer overwrite the baseline artifact, so the next successful run compares from the last verified baseline across the full unchecked span

## Validation
- parsed `action.yml` successfully with PyYAML
- asserted workflow invariants via script:
  - check step appears before write/upload
  - write/upload are both gated on `steps.check.outcome == 'success'`
  - `MATCH=0` is set before git operations
  - `MATCH=1` is only set after successful range-diff evaluation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fd9629c-b56e-47f9-b505-5ab174a15660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fd9629c-b56e-47f9-b505-5ab174a15660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

