### PR TITLE
Add filter-command input for custom change evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,48 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+## Custom filter command
+
+Use the `filter-command` input to run a custom command when changes are detected. The command receives the `git range-diff` output on stdin and via the `DSA_RANGE_DIFF` environment variable. Additional env vars (`DSA_HEAD_SHA`, `DSA_BASE_SHA`, `DSA_PREV_HEAD_SHA`, `DSA_PREV_BASE_SHA`, `DSA_MERGE_BASE`, `DSA_PREV_MERGE_BASE`) provide commit SHAs for running your own git commands.
+
+**Exit code convention:**
+- **Exit 0**: changes are **not** meaningful — keep approvals
+- **Non-zero**: changes **are** meaningful (or an error occurred) — dismiss approvals
+
+This fail-closed design ensures that if the filter command errors, approvals are dismissed as a safety default.
+
+### Example: Use Claude to evaluate changes
+
+```yaml
+jobs:
+  dismiss_stale_approvals:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dismiss stale pull request approvals
+        uses: withgraphite/dismiss-stale-approvals@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          filter-command: |
+            claude -p "You are reviewing a git range-diff from a pull request.
+            Determine if the changes are meaningful enough to require re-approval.
+            Trivial changes include: whitespace, comments, formatting, dependency
+            lock file updates, and auto-generated file changes.
+            If ALL changes are trivial, exit with code 0.
+            If ANY changes are meaningful, exit with code 1.
+            Here is the range-diff:"
+```
+
+### Example: Ignore changes to specific files
+
+```yaml
+          filter-command: |
+            git diff "$DSA_MERGE_BASE".."$DSA_HEAD_SHA" --name-only \
+              | grep -vE '(\.lock$|\.generated\.)' \
+              | grep -q . && exit 1 || exit 0
+```
+
+This keeps approvals (exit 0) when the only changed files match the exclusion pattern, and dismisses (exit 1) when other files are also changed.
+
 ## Issues and contributions
 
 We (the Graphite team) have limited staffing in this area (mainly due to the need for DSA being a relatively small number of customers), which is why the action is OSS in the first place. It was an issue an enterprise customer asked us for input on while trialing so we created it as the simplest possible solution for the problem as a proof-of-concept. We don't expect it to solve the problem for every single Graphite customer exactly as implemented, which is why some of our other larger customers have forked the repo for their desired use.

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,18 @@ inputs:
     description: 'Comment on the PR instead of dismissing approvals.'
     required: false
     default: false
+  filter-command:
+    description: >
+      A shell command to run when range-diff detects changes.
+      The range-diff output is passed via stdin and the DSA_RANGE_DIFF env var.
+      Additional env vars (DSA_HEAD_SHA, DSA_BASE_SHA, DSA_PREV_HEAD_SHA,
+      DSA_PREV_BASE_SHA, DSA_MERGE_BASE, DSA_PREV_MERGE_BASE) provide commit
+      SHAs for running your own git commands.
+      Exit 0 to keep approvals (changes are not meaningful).
+      Any non-zero exit dismisses approvals (changes are meaningful, or error).
+      When not set, all detected changes dismiss approvals (existing behavior).
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -75,14 +87,42 @@ runs:
         HAS_CHANGES=$(echo "$RANGE_DIFF" | awk '{print $3}' | grep -vq '^=$'; echo $?)
 
         if [ "$HAS_CHANGES" == "0" ]; then
-          echo "MATCH=0" >> $GITHUB_ENV
-          echo ::notice:: "PR was modified:
-        $(git range-diff --color=always "$PREV_MERGE_BASE".."${{ env.PREV_HEAD_SHA }}" "$MERGE_BASE".."${{ env.HEAD_SHA }}")"
+          # Range-diff detected changes
+          FILTER_CMD="$INPUT_FILTER_COMMAND"
+          if [ -n "$FILTER_CMD" ]; then
+            echo ::notice:: "Range-diff detected changes; running filter-command to evaluate significance"
+            export DSA_RANGE_DIFF="$RANGE_DIFF"
+            export DSA_PREV_HEAD_SHA="${{ env.PREV_HEAD_SHA }}"
+            export DSA_PREV_BASE_SHA="${{ env.PREV_BASE_SHA }}"
+            export DSA_HEAD_SHA="${{ env.HEAD_SHA }}"
+            export DSA_BASE_SHA="${{ env.BASE_SHA }}"
+            export DSA_PREV_MERGE_BASE="$PREV_MERGE_BASE"
+            export DSA_MERGE_BASE="$MERGE_BASE"
+
+            FILTER_EXIT=0
+            echo "$RANGE_DIFF" | eval "$FILTER_CMD" || FILTER_EXIT=$?
+
+            if [ "$FILTER_EXIT" == "0" ]; then
+              echo "MATCH=1" >> $GITHUB_ENV
+              echo ::notice:: "filter-command exited 0: changes deemed not meaningful, keeping approvals"
+            else
+              echo "MATCH=0" >> $GITHUB_ENV
+              echo ::notice:: "filter-command exited $FILTER_EXIT: dismissing approvals"
+              echo ::notice:: "PR was modified:
+            $(git range-diff --color=always "$PREV_MERGE_BASE".."${{ env.PREV_HEAD_SHA }}" "$MERGE_BASE".."${{ env.HEAD_SHA }}")"
+            fi
+          else
+            echo "MATCH=0" >> $GITHUB_ENV
+            echo ::notice:: "PR was modified:
+          $(git range-diff --color=always "$PREV_MERGE_BASE".."${{ env.PREV_HEAD_SHA }}" "$MERGE_BASE".."${{ env.HEAD_SHA }}")"
+          fi
         else
           echo "MATCH=1" >> $GITHUB_ENV
           echo "PR was not modified, range diff for debugging:"
           echo "$RANGE_DIFF"
         fi
+      env:
+        INPUT_FILTER_COMMAND: ${{ inputs.filter-command }}
 
     - name: Write SHAs to file
       if: steps.check.outcome == 'success'


### PR DESCRIPTION
## Summary

- Adds a new optional `filter-command` input that runs a user-provided shell command when `git range-diff` detects changes
- The command receives the range-diff via stdin and `DSA_*` env vars with commit SHAs, allowing flexible evaluation logic (e.g., AI-powered review with Claude, file pattern filtering)
- Uses a fail-closed exit code convention: exit 0 keeps approvals, any non-zero exit dismisses them
- Fully backwards compatible — behavior is unchanged when `filter-command` is not set

## Test plan

- [x] Verify existing behavior unchanged when `filter-command` is not provided
- [x] Test with `filter-command: "exit 0"` — approvals should always be kept when changes are detected
- [x] Test with `filter-command: "exit 1"` — approvals should always be dismissed
- [x] Test with a failing command (e.g., `nonexistent-command`) — approvals should be dismissed (fail-closed)
- [x] Verify `DSA_*` env vars are accessible from the filter command

🤖 Generated with [Claude Code](https://claude.com/claude-code)